### PR TITLE
Set File and Folder Bookmarks

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Export Active Artboard As PNG
     - Export Document Variables
     - Go To (another) Open Document
+    - Set File and Folder Bookmarks
+        - File bookmarks open up directly in Ai
+            - Accepted file types (taken from Ai open dialog): "ai", "ait", "pdf", "dxf", "avif", "BMP", "RLE", "DIB", "cgm", "cdr", "eps", "epsf", "ps", "emf", "gif", "heic", "heif", "eps", "epsf", "ps", "jpg", "jpe", "jpeg", "jpf", "jpx", "jp2", "j2k", "j2c", "jpc", "rtf", "doc", "docx", "PCX", "psd", "psb", "pdd", "PXR", "png", "pns", "svg", "svgz", "TGA", "VDA", "ICB", "VST", "txt", "tif", "tiff", "webp", "wmf"
+        - Folder bookmarks open on your system (Mac Finder or Windows Explorer)
+
+### Changed
+- Command "Load Scripts..." -> "Load Script(s)..."
+
+### Fixed
+- Incorrect localized var name for load script window
 
 ## [0.5.0] 2023-02-03
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -6,15 +6,16 @@ The format is based on [TODO.md](https://github.com/todomd/todo.md)
 
 ### Todo
 
-- [ ] file/folder bookmarks: allow users to save 'bookmarks' to commonly used files and folders, the use the File.execute() method to open them up.
 - [ ] startup screens customization: Allow the user to set what shows up when the command palette is first opened. Could be favorite commands, workflows, etc.
 - [ ] sort filtered items by most used: Track command usage counts in the user settings file, and use that count in the scoring algorithm for sorting the palette items.
 - [ ] store command history: Store the last 50 or 100 commands in the user settings file, then allow them to scroll up and down through them when the command palette is first presented (and no text has been entered).
+- [ ] alphabetize fonts and spot colors in document report
 
 ### Doing
 
-- [ ] new built-in commands: add new commands available to the api and not already accessible via the menu system
 
 ### Done
 
+- [x] file/folder bookmarks: allow users to save 'bookmarks' to commonly used files and folders, the use the File.execute() method to open them up.
+- [x] new built-in commands: add new commands available to the api and not already accessible via the menu system
 - [x] goto functionality: goto artboard, goto named object [(commit 0ad82b4)](https://github.com/joshbduncan/AiCommandPalette/commit/0ad82b4f250d49ebe5a0aacf87e7bd77bc4f46c0)

--- a/src/include/builtin.jsxinc
+++ b/src/include/builtin.jsxinc
@@ -24,6 +24,14 @@ function scriptAction(action) {
     case "loadScript":
       loadScripts();
       break;
+    case "setFileBookmark":
+      loadFileBookmark();
+      write = true;
+      break;
+    case "setFolderBookmark":
+      loadFolderBookmark();
+      write = true;
+      break;
     case "runAction":
       runAction();
       break;
@@ -333,13 +341,127 @@ function exportVariables() {
   }
 }
 
+/** Set bookmarked file to open in Ai from within Ai Command Palette. */
+function loadFileBookmark() {
+  var acceptedTypes = [
+    ".ai",
+    ".ait",
+    ".pdf",
+    ".dxf",
+    ".avif",
+    ".BMP",
+    ".RLE",
+    ".DIB",
+    ".cgm",
+    ".cdr",
+    ".eps",
+    ".epsf",
+    ".ps",
+    ".emf",
+    ".gif",
+    ".heic",
+    ".heif",
+    ".eps",
+    ".epsf",
+    ".ps",
+    ".jpg",
+    ".jpe",
+    ".jpeg",
+    ".jpf",
+    ".jpx",
+    ".jp2",
+    ".j2k",
+    ".j2c",
+    ".jpc",
+    ".rtf",
+    ".doc",
+    ".docx",
+    ".PCX",
+    ".psd",
+    ".psb",
+    ".pdd",
+    ".PXR",
+    ".png",
+    ".pns",
+    ".svg",
+    ".svgz",
+    ".TGA",
+    ".VDA",
+    ".ICB",
+    ".VST",
+    ".txt",
+    ".tif",
+    ".tiff",
+    ".webp",
+    ".wmf",
+  ]; // file types taken from Ai open dialog
+  re = new RegExp(acceptedTypes.toString().replace(/,/g, "|") + "$", "i");
+  var files = loadFileTypes(localize(locStrings.bm_set_bookmark), true, re);
+  if (files.length > 0) {
+    var f, key, fname;
+    for (var i = 0; i < files.length; i++) {
+      f = files[i];
+      fname = decodeURI(f.name);
+      key = localize(locStrings.bookmark) + ": " + fname;
+      if (data.commands.bookmark.hasOwnProperty(key)) {
+        if (
+          !Window.confirm(
+            localize(locStrings.bm_already_loaded),
+            "noAsDflt",
+            localize(locStrings.bm_already_loaded_title)
+          )
+        )
+          continue;
+      }
+      try {
+        data.commands.bookmark[key] = {
+          name: fname,
+          type: "bookmark",
+          path: f.fsName,
+          bookmarkType: "file",
+        };
+      } catch (e) {
+        alert(localize(locStrings.bm_error_loading, f.fsName));
+      }
+    }
+  }
+}
+
+/** Set bookmarked folder to open on system from within Ai Command Palette. */
+function loadFolderBookmark() {
+  var f, key, fname;
+  f = Folder.selectDialog(localize(locStrings.bm_set_bookmark));
+  if (f) {
+    fname = decodeURI(f.name);
+    key = localize(locStrings.bookmark) + ": " + fname;
+    if (data.commands.bookmark.hasOwnProperty(key)) {
+      if (
+        !Window.confirm(
+          localize(locStrings.bm_already_loaded),
+          "noAsDflt",
+          localize(locStrings.bm_already_loaded_title)
+        )
+      )
+        return;
+    }
+    try {
+      data.commands.bookmark[key] = {
+        name: fname,
+        type: "bookmark",
+        path: f.fsName,
+        bookmarkType: "folder",
+      };
+    } catch (e) {
+      alert(localize(locStrings.bm_error_loading, f.fsName));
+    }
+  }
+}
+
 /** Load external scripts into Ai Command Palette. */
 function loadScripts() {
-  var files = loadFileTypes(
-    localize(locStrings.cp_config_load_scripts),
-    true,
-    ".jsx$|.js$"
-  );
+  var acceptedTypes = [".jsx", ".js"];
+  re = new RegExp(acceptedTypes.toString().replace(/,/g, "|") + "$", "i");
+  var files = loadFileTypes(localize(locStrings.sc_load_script), true, ".jsx$|.js$");
   if (files.length > 0) {
     var f, key, fname;
     for (var i = 0; i < files.length; i++) {

--- a/src/include/commands.jsxinc
+++ b/src/include/commands.jsxinc
@@ -123,6 +123,27 @@ function executeCommand(command) {
         alert(localize(locStrings.ac_error_execution, command, e));
       }
       break;
+    case "bookmark":
+      f =
+        commandData.bookmarkType == "file"
+          ? new File(commandData.path)
+          : new Folder(commandData.path);
+      if (!f.exists) {
+        alert(localize(locStrings.bm_error_exists, commandData.path));
+        delete data.commands.bookmark[command];
+        settings.save();
+      } else {
+        try {
+          if (commandData.bookmarkType == "file") {
+            app.open(f);
+          } else {
+            f.execute();
+          }
+        } catch (e) {
+          alert(localize(locStrings.sc_error_execution, commandData.name, e));
+        }
+      }
+      break;
     case "script":
       f = new File(commandData.path);
       if (!f.exists) {

--- a/src/include/config.jsxinc
+++ b/src/include/config.jsxinc
@@ -56,6 +56,7 @@ settings.save = function () {
   var file = this.file();
   var obj = {
     commands: {
+      bookmark: data.commands.bookmark,
       script: data.commands.script,
       workflow: data.commands.workflow,
     },

--- a/src/include/data.jsxinc
+++ b/src/include/data.jsxinc
@@ -12,6 +12,22 @@ var locStrings = {
     de: "",
     ru: "",
   },
+  bookmark: { en: "Bookmark", de: "", ru: "" },
+  bm_already_loaded: {
+    en: "Bookmark already set.\nWould you like to replace the previous bookmark with the new one?",
+    de: "",
+    ru: "",
+  },
+  bm_already_loaded_title: { en: "Bookmark Load Conflict", de: "", ru: "" },
+  bm_error_execution: { en: "Error opening bookmark:\n%1\n\n%2", de: "", ru: "" },
+  bm_error_exists: {
+    en: "Bookmark no longer exists at original path. Try reloading.\n%1",
+    de: "",
+    ru: "",
+  },
+  bm_error_loading: { en: "Error loading bookmark:\n%1", de: "", ru: "" },
+  bm_set_bookmark: { en: "Set Bookmark(s)", de: "", ru: "" },
+  bm_total_loaded: { en: "Total bookmarks loaded:\n%1", de: "", ru: "" },
   cancel: { en: "Cancel", de: "Abbrechen", ru: "Отмена" },
   cd_all: {
     en: "All Built-In Menu Commands",
@@ -187,6 +203,7 @@ var locStrings = {
     de: "Fehler beim Laden des Skripts:\n%1",
     ru: "Ошибка загрузки скрипта:\n%1",
   },
+  sc_load_script: { en: "Load Script(s)", de: "", ru: "" },
   sc_none_selected: {
     en: "No script files selected.\nMust be JavaScript '.js' or '.jsx' files.",
     de: "Keine Skriptdateien ausgewählt.\nEs müssen JavaScript-'.js'- oder '.jsx'-Dateien sein.",
@@ -5660,7 +5677,17 @@ var builtCommands = {
     config_loadScript: {
       action: "loadScript",
       type: "config",
-      loc: { en: "Load Scripts...", de: "Skripte laden …", ru: "Загрузить скрипты" },
+      loc: { en: "Load Script(s)...", de: "Skripte laden …", ru: "Загрузить скрипты" },
+    },
+    config_setFileBookmark: {
+      action: "setFileBookmark",
+      type: "config",
+      loc: { en: "Set File Bookmark(s)...", de: "", ru: "" },
+    },
+    config_setFolderBookmark: {
+      action: "setFolderBookmark",
+      type: "config",
+      loc: { en: "Set Folder Bookmark...", de: "", ru: "" },
     },
     config_hideCommand: {
       action: "hideCommand",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -33,6 +33,7 @@ See the LICENSE file for details.
 
   var data = {
     commands: {
+      bookmark: {},
       script: {},
       workflow: {},
       defaults: builtCommands.defaults,


### PR DESCRIPTION
- File bookmarks open up directly in Ai - Accepted file types (taken from Ai open dialog): "ai", "ait", "pdf", "dxf", "avif", "BMP", "RLE", "DIB", "cgm", "cdr", "eps", "epsf", "ps", "emf", "gif", "heic", "heif", "eps", "epsf", "ps", "jpg", "jpe", "jpeg", "jpf", "jpx", "jp2", "j2k", "j2c", "jpc", "rtf", "doc", "docx", "PCX", "psd", "psb", "pdd", "PXR", "png", "pns", "svg", "svgz", "TGA", "VDA", "ICB", "VST", "txt", "tif", "tiff", "webp", "wmf"
- Folder bookmarks open on your system (Mac Finder or Windows Explorer)